### PR TITLE
Set up registration endpoint to allow more people to submit extractors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 venv/
 .DS_Store
 instance/config.py
+instance/config.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ __pycache__
 venv/
 .DS_Store
 instance/config.py
-instance/config.json

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ db.getCollection('transformations').createIndex( { transformationId: "text", des
 Each line of the configuration file should contain one configuration setting and its value. Use an equal sign (=) between the setting and the value, and put quotes (") around the value. Comments can be made by adding a pound sign (#) before what you want to comment out.
 
 2. Available Configuration Settings
-
-TRANSFORMATIONS_DATABASE_URI: The URI for the Mongo database. Use the Connection String URI format as described at https://docs.mongodb.com/manual/reference/connection-string/.
+```
+TRANSFORMATIONS_DATABASE_URI: The URI for the Mongo database. Use the Connection String URI format as
+                              described at https://docs.mongodb.com/manual/reference/connection-string/.
 TRANSFORMATIONS_DATABASE_NAME: The name of the Mongo database.
 LDAP_HOSTNAME: The full URI to the LDAP server. Include the port if non-standard.
 LDAP_GROUP: The LDAP group name that contains people that are authorized.
@@ -138,8 +139,12 @@ LDAP_GROUP_DN: Applied to the base DN to find groups.
 LDAP_OBJECTCLASS: An LDAP object class that applies to users.
 LDAP_TRUST_ALL_CERTIFICATES: A True/False setting.
 ADMINS: A list of users in LDAP that have administrator permissions to the catalog.
-URL_PREFIX: This can be used if you need to prefix all URLs with a prefix. Then you can set up a proxy to forward to the given server with this prefix and have the routes work with the prefix. This should always start with a slash (/).
-
+URL_PREFIX: This can be used if you need to prefix all URLs with a prefix. Then you can set up a proxy
+            to forward to the given server with this prefix and have the routes work with the prefix.
+            This should always start with a slash (/).
+ANONYMOUS_SUBMISSION: A True/False setting. When set to True, allows unauthenticated users to submit
+                      transformations. Defaults to False.
+```
 ## Docker
 
 1. Build image
@@ -162,6 +167,12 @@ To run the docker image you may like the following command line:
 ```bash
 % docker run --rm -d -p 5000:5000 -v path_to_conf/config.py:/app/instance/config.py transformation
 ```
+
+3. Run locally using docker-compose
+
+docker-compose is provided as an easy test environment. An initial config.json is provided for ease of testing that is set to use the values from the docker-compose. This allows for a quick clone of the repository and a simple `docker-compose up` to start using an unsecured version of the catalog locally. This configuration file allows for anyone to submit transformations and exposes the catalog on local port 5000, suitable for testing, but likely not what you want for production.
+
+Beyond simply cloning the repo and using `docker-compose up`, you may want to make local changes and test those. `docker-compose up --build` will rebuild the images, and clear the database volume. The database can be empty and still function with the catalog, with the only failure being needing to create an index on the database for search to work. This bug may be addressed in future releases, automating creating the index.
 
 ## Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ db.getCollection('transformations').createIndex( { transformationId: "text", des
 Each line of the configuration file should contain one configuration setting and its value. Use an equal sign (=) between the setting and the value, and put quotes (") around the value. Comments can be made by adding a pound sign (#) before what you want to comment out.
 
 2. Available Configuration Settings
-
-TRANSFORMATIONS_DATABASE_URI: The URI for the Mongo database. Use the Connection String URI format as described at https://docs.mongodb.com/manual/reference/connection-string/.
+```
+TRANSFORMATIONS_DATABASE_URI: The URI for the Mongo database. Use the Connection String URI format as
+                              described at https://docs.mongodb.com/manual/reference/connection-string/.
 TRANSFORMATIONS_DATABASE_NAME: The name of the Mongo database.
 LDAP_HOSTNAME: The full URI to the LDAP server. Include the port if non-standard.
 LDAP_GROUP: The LDAP group name that contains people that are authorized.
@@ -138,8 +139,12 @@ LDAP_GROUP_DN: Applied to the base DN to find groups.
 LDAP_OBJECTCLASS: An LDAP object class that applies to users.
 LDAP_TRUST_ALL_CERTIFICATES: A True/False setting.
 ADMINS: A list of users in LDAP that have administrator permissions to the catalog.
-URL_PREFIX: This can be used if you need to prefix all URLs with a prefix. Then you can set up a proxy to forward to the given server with this prefix and have the routes work with the prefix. This should always start with a slash (/).
-
+URL_PREFIX: This can be used if you need to prefix all URLs with a prefix. Then you can set up a proxy
+            to forward to the given server with this prefix and have the routes work with the prefix. 
+            This should always start with a slash (/).
+ANONYMOUS_SUBMISSION: A True/False setting. When set to True, allows unauthenticated users to submit 
+                      transformations. Defaults to False.
+```
 ## Docker
 
 1. Build image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2.0'
+services:
+  mongodb:
+    image: mongo:4.2
+    volumes:
+      - "dbdata:/data/db"
+  catalog:
+    ports:
+    - "5000:5000"
+    volumes:
+    - ./instance:/app/instance
+    build: .
+    image: transformations-catalog
+
+volumes:
+  dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
     - ./instance:/app/instance
     build: .
-    image: transformations-catalog
+    image: clowder/catalog
 
 volumes:
   dbdata:

--- a/instance/config.json
+++ b/instance/config.json
@@ -1,0 +1,15 @@
+{
+  "TRANSFORMATIONS_DATABASE_URI": "mongodb://mongodb:27017",
+  "TRANSFORMATIONS_DATABASE_NAME": "transformations_catalog_test",
+  "LDAP_HOSTNAME": "",
+  "LDAP_GROUP": "",
+  "LDAP_BASE_DN": "",
+  "LDAP_USER_DN": "",
+  "LDAP_GROUP_DN": "",
+  "LDAP_OBJECTCLASS": "inetorgperson",
+  "LDAP_TRUST_ALL_CERTIFICATES": "false",
+  "ADMINS": "",
+  "URL_PREFIX": "",
+  "REGISTRATION_URL": "",
+  "ANONYMOUS_SUBMISSION": "true"
+}

--- a/kubernetes/transformations-catalog-secret.yaml
+++ b/kubernetes/transformations-catalog-secret.yaml
@@ -16,5 +16,7 @@ data:
     "LDAP_OBJECTCLASS":"",
     "LDAP_TRUST_ALL_CERTIFICATES":"",
     "ADMINS":"",
-    "URL_PREFIX":""
+    "URL_PREFIX":"",
+    "ANONYMOUS_SUBMISSION":"False",
+    "REGISTRATION_URL":""
     }

--- a/transformations/auth.py
+++ b/transformations/auth.py
@@ -73,3 +73,10 @@ def load_logged_in_user():
 def logout():
     session.clear()
     return redirect(url_for('pages.home'))
+
+@bp.route('/register')
+def register():
+    if 'REGISTRATION_URL' in current_app.config.keys() and current_app.config['REGISTRATION_URL']:
+        return redirect(current_app.config['REGISTRATION_URL'])
+    else:
+        return "Local registration not yet implemented", 501

--- a/transformations/pages.py
+++ b/transformations/pages.py
@@ -65,7 +65,7 @@ def softwares():
 @bp.route('/transformations', methods=('GET', 'POST'))
 def post_transformation():
     # Check if user has logged in or anonymous submission is allowed
-    if g.user is not None or current_app.config["ANONYMOUS_SUBMISSION"] is "True":
+    if g.user is not None or current_app.config["ANONYMOUS_SUBMISSION"].lower() == "true":
         if request.method == 'POST':
 
             transformation_type = request.form['radioOptions']

--- a/transformations/pages.py
+++ b/transformations/pages.py
@@ -47,7 +47,7 @@ def home():
     if software:
         transformations = collection.transformations.find({"dependencies": software})
     else:
-        transformations = collection.transformations.find()
+        transformations = collection.transformations.find({"status": "approved"})
     return render_template('pages/home.html', transformations = transformations, getIcon = getIcon,
                            hasIcons = hasIcons)
 
@@ -64,8 +64,8 @@ def softwares():
 
 @bp.route('/transformations', methods=('GET', 'POST'))
 def post_transformation():
-    # Check if user has logged in
-    if g.user is not None:
+    # Check if user has logged in or anonymous submission is allowed
+    if g.user is not None or current_app.config["ANONYMOUS_SUBMISSION"] is "True":
         if request.method == 'POST':
 
             transformation_type = request.form['radioOptions']
@@ -117,7 +117,7 @@ def post_transformation():
             except ValueError as e:
                 print("Invalid JSON.")
                 raise
-            
+
         return render_template('pages/post_transformation.html')
     return redirect(url_for('auth.login'))
 

--- a/transformations/templates/auth/login.html
+++ b/transformations/templates/auth/login.html
@@ -21,6 +21,9 @@
             </div>
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>
+        <div>
+            Don't have an account? <a href="{{ url_for('auth.register') }}">Register Here!</a>
+        </div>
     </div>
     <div class="col-4">
     </div>


### PR DESCRIPTION
Filter the default list of extractors by approved.
Add a property for allowing anonymous submission.
Set up a registration endpoint that will redirect to a given URL, or give a 501 error if no external URL is provided.
Link to the registration endpoint on the login page.

Currently there is no mechanism to limit how many extractions may be submitted. If that is a problem, I can look at how to do that either as part of this PR, or as a new PR.
I did also verify that the transformations page does work, so the short form where you submit the json for the converter/extractor will work for the world. I did not error check what happens if not all the needed information is added to the form.
If the config.json (or config.py if still using that) does not contain a "REGISTRATION_URL" property with a link to a registration link then a 501 error will be returned that states that local registration is not implemented. If that property is present then the registration url will be redirected to from the registration endpoint.
There is an additional recognized property to allow anonymous submissions that defaults to false.