### PR TITLE
docker-compose for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 venv/
 .DS_Store
 instance/config.py
+instance/config.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ __pycache__
 venv/
 .DS_Store
 instance/config.py
-instance/config.json

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ db.getCollection('transformations').createIndex( { transformationId: "text", des
 Each line of the configuration file should contain one configuration setting and its value. Use an equal sign (=) between the setting and the value, and put quotes (") around the value. Comments can be made by adding a pound sign (#) before what you want to comment out.
 
 2. Available Configuration Settings
-
-TRANSFORMATIONS_DATABASE_URI: The URI for the Mongo database. Use the Connection String URI format as described at https://docs.mongodb.com/manual/reference/connection-string/.
+```
+TRANSFORMATIONS_DATABASE_URI: The URI for the Mongo database. Use the Connection String URI format as
+                              described at https://docs.mongodb.com/manual/reference/connection-string/.
 TRANSFORMATIONS_DATABASE_NAME: The name of the Mongo database.
 LDAP_HOSTNAME: The full URI to the LDAP server. Include the port if non-standard.
 LDAP_GROUP: The LDAP group name that contains people that are authorized.
@@ -138,8 +139,12 @@ LDAP_GROUP_DN: Applied to the base DN to find groups.
 LDAP_OBJECTCLASS: An LDAP object class that applies to users.
 LDAP_TRUST_ALL_CERTIFICATES: A True/False setting.
 ADMINS: A list of users in LDAP that have administrator permissions to the catalog.
-URL_PREFIX: This can be used if you need to prefix all URLs with a prefix. Then you can set up a proxy to forward to the given server with this prefix and have the routes work with the prefix. This should always start with a slash (/).
-
+URL_PREFIX: This can be used if you need to prefix all URLs with a prefix. Then you can set up a proxy
+            to forward to the given server with this prefix and have the routes work with the prefix.
+            This should always start with a slash (/).
+ANONYMOUS_SUBMISSION: A True/False setting. When set to True, allows unauthenticated users to submit
+                      transformations. Defaults to False.
+```
 ## Docker
 
 1. Build image
@@ -162,6 +167,12 @@ To run the docker image you may like the following command line:
 ```bash
 % docker run --rm -d -p 5000:5000 -v path_to_conf/config.py:/app/instance/config.py transformation
 ```
+
+3. Run locally using docker-compose
+
+docker-compose is provided as an easy test environment. An initial config.json is provided for ease of testing that is set to use the values from the docker-compose. This allows for a quick clone of the repository and a simple `docker-compose up` to start using an unsecured version of the catalog locally. This configuration file allows for anyone to submit transformations and exposes the catalog on local port 5000, suitable for testing, but likely not what you want for production.
+
+Beyond simply cloning the repo and using `docker-compose up`, you may want to make local changes and test those. `docker-compose up --build` will rebuild the images, and clear the database volume. The database can be empty and still function with the catalog, with the only failure being needing to create an index on the database for search to work. This bug may be addressed in future releases, automating creating the index.
 
 ## Kubernetes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2.0'
+services:
+  mongodb:
+    image: mongo:4.2
+    volumes:
+      - "dbdata:/data/db"
+  catalog:
+    ports:
+    - "5000:5000"
+    volumes:
+    - ./instance:/app/instance
+    build: .
+    image: transformations-catalog
+
+volumes:
+  dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
     - ./instance:/app/instance
     build: .
-    image: transformations-catalog
+    image: clowder/catalog
 
 volumes:
   dbdata:

--- a/instance/config.json
+++ b/instance/config.json
@@ -1,0 +1,15 @@
+{
+  "TRANSFORMATIONS_DATABASE_URI": "mongodb://mongodb:27017",
+  "TRANSFORMATIONS_DATABASE_NAME": "transformations_catalog_test",
+  "LDAP_HOSTNAME": "",
+  "LDAP_GROUP": "",
+  "LDAP_BASE_DN": "",
+  "LDAP_USER_DN": "",
+  "LDAP_GROUP_DN": "",
+  "LDAP_OBJECTCLASS": "inetorgperson",
+  "LDAP_TRUST_ALL_CERTIFICATES": "false",
+  "ADMINS": "",
+  "URL_PREFIX": "",
+  "REGISTRATION_URL": "",
+  "ANONYMOUS_SUBMISSION": "true"
+}


### PR DESCRIPTION
Added a docker-compose for ease of testing.
Added a section to the README about using the docker-compose.
Added a config.json that is set for easy use of docker-compose in a non-secure manner.

This relies on the ANONYMOUS_SUBMISSION that has been added in the add-registration branch.

To test:
Clone repo
Run `docker-compose up --build`
Attempt to access a new local catalog at localhost:5000 in your web browser
The catalog home page should be there, though with no data
Submit an extractor.
Stop the docker-compose.
Restart the docker-compose using `docker-compose up`
Attempt to access the local catalog (with the previously added extractor) at localhost:5000
Note that the volume seems to empty every time `docker-compose up --build` is called
This can be avoided by building the transformation-catalog image in a separate command, and simply calling `docker-compose up` after making changes to the image