### PR TITLE
Automate creating index for search

### DIFF
--- a/transformations/db.py
+++ b/transformations/db.py
@@ -1,5 +1,5 @@
 from flask import current_app, g
-from pymongo import MongoClient
+from pymongo import MongoClient, TEXT
 
 def get_db():
     if 'db' not in g:

--- a/transformations/db.py
+++ b/transformations/db.py
@@ -5,6 +5,9 @@ def get_db():
     if 'db' not in g:
         client = MongoClient(current_app.config['TRANSFORMATIONS_DATABASE_URI'])
         g.db = client
+        database = client.get_database(current_app.config['TRANSFORMATIONS_DATABASE_NAME'])
+        collection = database.get_collection("transformations")
+        collection.create_index([('transformationId', TEXT), ('description', TEXT)])
     return g.db
 
 def close_db(e=None):


### PR DESCRIPTION
Added the index creation to get_db, but only where the db is not already populated. This should create the index upon start of the app, and in local testing has been effective even on an empty database.

To test you can start with the catalog pointing to an empty database or a database without the index.
Upon starting of the catalog the index will be created. This can be verified with Compass, or your favorite MongoDB browser.
This will not recreate the index if you start the catalog, then delete the index.