### PR TITLE
Add info to details page

### DIFF
--- a/transformations/pages.py
+++ b/transformations/pages.py
@@ -47,7 +47,7 @@ def home():
     if software:
         transformations = collection.transformations.find({"dependencies": software})
     else:
-        transformations = collection.transformations.find()
+        transformations = collection.transformations.find({"status": "approved"})
     return render_template('pages/home.html', transformations = transformations, getIcon = getIcon,
                            hasIcons = hasIcons)
 
@@ -64,8 +64,8 @@ def softwares():
 
 @bp.route('/transformations', methods=('GET', 'POST'))
 def post_transformation():
-    # Check if user has logged in
-    if g.user is not None:
+    # Check if user has logged in or anonymous submission is allowed
+    if g.user is not None or current_app.config["ANONYMOUS_SUBMISSION"] is "True":
         if request.method == 'POST':
 
             transformation_type = request.form['radioOptions']
@@ -117,7 +117,7 @@ def post_transformation():
             except ValueError as e:
                 print("Invalid JSON.")
                 raise
-            
+
         return render_template('pages/post_transformation.html')
     return redirect(url_for('auth.login'))
 
@@ -138,11 +138,14 @@ def view_transformation(transformation_id):
         db = get_db()
         database = db[current_app.config['TRANSFORMATIONS_DATABASE_NAME']]
         transformation  = database.transformations.find_one({ "_id": ObjectId(transformation_id)})
+        alltransformations = database.transformations.find({"transformationId":
+                                                             transformation["transformationId"] }).sort("version", -1)
 
     except Exception as e:
         print("Exception")
         raise
-    return render_template('pages/view_transformation.html', transformation = transformation, getIcon = getIcon,
+    return render_template('pages/view_transformation.html', originalTransformation = transformation,
+                           transformations = alltransformations, getIcon = getIcon,
                            replaceEmptyString = replaceEmptyString)
 
 

--- a/transformations/pages.py
+++ b/transformations/pages.py
@@ -7,6 +7,7 @@ import gridfs
 import codecs
 import json
 import datetime
+from pymongo.collation import Collation
 
 bp = Blueprint('pages', __name__)
 
@@ -139,7 +140,8 @@ def view_transformation(transformation_id):
         database = db[current_app.config['TRANSFORMATIONS_DATABASE_NAME']]
         transformation  = database.transformations.find_one({ "_id": ObjectId(transformation_id)})
         alltransformations = database.transformations.find({"transformationId":
-                                                             transformation["transformationId"] }).sort("version", -1)
+                                                             transformation["transformationId"] }).sort("version", -1).\
+                                                             collation(Collation(locale='en_US', numericOrdering=True))
 
     except Exception as e:
         print("Exception")

--- a/transformations/static/css/main.css
+++ b/transformations/static/css/main.css
@@ -10,3 +10,7 @@
 .btn-group-sm>.btn, .btn-sm {
     padding: 0rem .5rem;
 }
+
+.version {
+    text-align: right;
+}

--- a/transformations/templates/pages/view_transformation.html
+++ b/transformations/templates/pages/view_transformation.html
@@ -38,10 +38,31 @@
                         <p>{{replaceEmptyString(transformation.dockerImageName)}}</p>
                         <h4>Author</h4>
                         <p>{{transformation.author}}</p>
+                        {% if transformation.contributors|length > 0 %}
+                        <h4>Contributors</h4>
+                            <p>
+                            {% for contributor in transformation.contributors %}
+                                {% if loop.last %}
+                                    {{ contributor }}
+                                {% else %}
+                                    {{ contributor }},
+                                {% endif %}
+                            {% endfor %}
+                            </p>
+                        {% endif %}
                         <h4>Last Modified</h4>
                         <p>{{transformation.updated.date()}}</p>
                     </div>
                 </div>
+                {% if transformation.bibtex|length > 0 and transformation.bibtex[0] != "" %}
+                <div>
+                    <hr />
+                    <h4>Citations</h4>
+                    {% for citation in transformation.bibtex %}
+                        <p>{{ citation }}</p>
+                    {% endfor %}
+                </div>
+                {% endif %}
             </div>
         </div>
     {% endfor %}

--- a/transformations/templates/pages/view_transformation.html
+++ b/transformations/templates/pages/view_transformation.html
@@ -3,41 +3,48 @@
 
 {% block content %}
 <div class="container">
-    <div class="card">
-        <h4 class="card-header">{{transformation.transformationId }}</h4>
-        <div class="card-body">
-            <div class="row">
-                <div class="col-6" style="padding-right:20px; border-right: 1px solid #ccc;">
-                    <h4>Description</h4>
-                    <p>{{transformation.description}}</p>
-                    <hr />
+    {% for transformation in transformations %}
+        {% if originalTransformation == transformation %}
+            <div class="card" style="border: 3px solid green">
+        {% else %}
+            <div class="card">
+        {% endif %}
+            <h4 class="card-header">{{transformation.transformationId }}</h4>
+            <h6 class="version">Version: {{ transformation.version }}</h6>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-6" style="padding-right:20px; border-right: 1px solid #ccc;">
+                        <h4>Description</h4>
+                        <p>{{transformation.description}}</p>
+                        <hr />
 
-                    <h4>Source Code URL</h4>
-                    <p>   {{transformation.url}}</p>
-                </div>
-                <div class="col-6">
-                    <h4>Software Used</h4>
-                    {% for software in transformation.dependencies  %}
-                    <p>{{software}}
-                        {% if getIcon(software) %}
-                        <a href="{{ url_for('pages.home', software=software) }}">
-                            <img class="icon"  src="data:image/png;base64,{{getIcon(software)}}"
-                                 alt="Icon of the tool {{transformation.title}}" >
-                        </a>
-                    </p>
-                    {% endif%}
-                    {% endfor%}
+                        <h4>Source Code URL</h4>
+                        <p><a href="{{ transformation.url }}">{{ transformation.url }}</a></p>
+                    </div>
+                    <div class="col-6">
+                        <h4>Software Used</h4>
+                        {% for software in transformation.dependencies  %}
+                        <p>{{software}}
+                            {% if getIcon(software) %}
+                            <a href="{{ url_for('pages.home', software=software) }}">
+                                <img class="icon"  src="data:image/png;base64,{{getIcon(software)}}"
+                                     alt="Icon of the tool {{transformation.title}}" >
+                            </a>
+                        </p>
+                        {% endif%}
+                        {% endfor%}
 
-                    <h4>Docker Image Name</h4>
-                    <p>{{replaceEmptyString(transformation.dockerImageName)}}</p>
-                    <h4>Author</h4>
-                    <p>{{transformation.author}}</p>
-                    <h4>Last Modified</h4>
-                    <p>{{transformation.updated.date()}}</p>
+                        <h4>Docker Image Name</h4>
+                        <p>{{replaceEmptyString(transformation.dockerImageName)}}</p>
+                        <h4>Author</h4>
+                        <p>{{transformation.author}}</p>
+                        <h4>Last Modified</h4>
+                        <p>{{transformation.updated.date()}}</p>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    {% endfor %}
 
 </div>
 {% endblock %}


### PR DESCRIPTION
This adds all versions of a single transformation based on transformationID. It marks the current chosen extractor with a green border.
Added citations, contributors, and version to the details page.
Altered the URL to actually link to the given page.