### PR TITLE
Clowder auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,11 @@ Each line of the configuration file should contain one configuration setting and
 
 TRANSFORMATIONS_DATABASE_URI: The URI for the Mongo database. Use the Connection String URI format as described at https://docs.mongodb.com/manual/reference/connection-string/.
 TRANSFORMATIONS_DATABASE_NAME: The name of the Mongo database.
-LDAP_HOSTNAME: The full URI to the LDAP server. Include the port if non-standard.
+AUTH_TYPE: The authorization to use, currently only supports LDAP and Clowder.
+AUTH_HOSTNAME: The server to use for authentication. Include the port if non-standard.
+AUTH_URL: The URL endpoint to verify authentication. Not used for LDAP.
+SSL_CERT: If Clowder uses SSL then authentication requires a local public certificate. If unspecified will attempt to use HTTP rather than HTTPS for authentication.
+LDAP_HOSTNAME: The full URI to the LDAP server. Include the port if non-standard. ** Depreciated. Use AUTH_HOSTNAME. **
 LDAP_GROUP: The LDAP group name that contains people that are authorized.
 LDAP_BASE_DN: The base DN for the LDAP server.
 LDAP_USER_DN: Applied to the base DN to find users.

--- a/instance/config.json.template
+++ b/instance/config.json.template
@@ -1,6 +1,9 @@
 {
   "TRANSFORMATIONS_DATABASE_URI": "mongodb://localhost:27017",
   "TRANSFORMATIONS_DATABASE_NAME": "transformations_catalog",
+  "AUTH_TYPE": "LDAP",
+  "AUTH_URL": "",
+  "AUTH_HOSTNAME": "",
   "LDAP_HOSTNAME": "",
   "LDAP_GROUP": "",
   "LDAP_BASE_DN": "",

--- a/transformations/auth.py
+++ b/transformations/auth.py
@@ -20,7 +20,8 @@ def login():
         password = request.form['password']
         error = None
         user = None
-        if re.search(r'LDAP', current_app.config["AUTH_TYPE"], flags=re.IGNORECASE):
+        if re.search(r'LDAP', current_app.config["AUTH_TYPE"], flags=re.IGNORECASE) or "LDAP_HOSTNAME" \
+                                                                            in current_app.config.keys():
             if "AUTH_HOSTNAME" in current_app.config.keys():
                 ldap_hostname = current_app.config['AUTH_HOSTNAME']
             else:


### PR DESCRIPTION
This updates the config file and authorization to make use of LDAP or Clowder.

The LDAP is basically unchanged, but Clowder uses a AUTH_URL to send a basic authentication request to. If this isn't the preferred way to authorized to Clowder, then it should be changed now.